### PR TITLE
Foutje in oefening 16 is verbeterd

### DIFF
--- a/hoofdstuk_3_oefeningen.tex
+++ b/hoofdstuk_3_oefeningen.tex
@@ -696,13 +696,13 @@ We gooien dit in matrixvorm:
 \begin{pmatrix}[cccc|c]
 1 &0 &0 &0 & a_1 \\
 0 &1 &0 &0 & a_2-a_1 \\
-0 &0 &1 &0 & a_3-a_2-a_1 \\
-0 &0 &0 &1 & a_4-a_3-a_2-a_1
+0 &0 &1 &0 & a_3-a_2\\
+0 &0 &0 &1 & a_4-a_3
 \end{pmatrix}
 \]
 De co\"ordinaten van $v$ ten opzichte van de nieuwe basis zijn dus:
 \[
-(a_1, a_2-a_1, a_3-a_2-a_1, a_4-a_3-a_2-a_1)
+(a_1, a_2-a_1, a_3-a_2, a_4-a_3)
 \]
 
 \subsection{Oefening 17}


### PR DESCRIPTION
De coördinaten van v zijn (a1, a2-a1, a3-a2, a4-a3) in plaats van (a1,a2-a1, a3-a1-a2, a4-a3-a2-a1)